### PR TITLE
Fix typos

### DIFF
--- a/5-match.nextjournal.md
+++ b/5-match.nextjournal.md
@@ -269,7 +269,7 @@ You show Ubuku the result of the trade using the function you created earlier:
 (format-stock-check (stock-check :blue-energy :units/CH4))
 ```
 
-They are happy that this works as he sees the 1000 credits move from Blue energy to Tombaugh Resources Ltd.
+They are happy that this works as he sees the 100 credits move from Blue energy to Tombaugh Resources Ltd.
 and 10 units of Methane the other way.
 
 Ubuku asks if you can show them what would happen if the state of funds in the account of a buyer did not match expectations.

--- a/7-evict.nextjournal.md
+++ b/7-evict.nextjournal.md
@@ -175,13 +175,13 @@ All the data associated with the specified `:xt/id` has been removed from the XT
 
 The transaction history is immutable.
 This means the transactions will never be removed.
-You assure Ilex that the documents are completely removed from XTDB, you can show this by looking at the `history-descending` information for each person.
+You assure Ilex that the documents are completely removed from XTDB, you can show this by looking at the `entity-history` information for each person.
 
 ```clojure
 (xt/entity-history (xt/db node)
-                     :person/kaarlang
-                     :desc
-                     {:with-docs? true})
+                   :person/kaarlang
+                   :desc
+                   {:with-docs? true})
 ```
 
 You show the results to Kaarlang who is happy that there his details are no longer a part of the ships logs.


### PR DESCRIPTION
Fixes #20.

I'm not sure about the `history-descending` change. From context (and looking at the XTDB source) I'm assuming that it used to be the public API function to retrieve an entity's history, but was replaced with `entity-history`. Please confirm, and/or change as appropriate. :slightly_smiling_face: